### PR TITLE
Fix amethyst and ACM compatibility

### DIFF
--- a/Advanced Classes Mod/Data/s/advanced classes skills.erm
+++ b/Advanced Classes Mod/Data/s/advanced classes skills.erm
@@ -11989,8 +11989,8 @@ Close Dialouge
 !!SN:W^Paladin_Experience_Att^/0; !!SN:W^Paladin_Experience_Def^/0;
 
 !?FU(OnCombatRound)&v997=0;             [On First visible combat round]
-!!SN:W^Typhon_Third_Upgrade_Mod_Active^/?y10; [Check for Third Upgrade Mod]
-!!FU&y10=0:E;
+!!SN:F^PluginExists^/^amethyst2_4^; [Check for Amethyst]
+!!FU&v1=0:E
 !!re i/0/41;
   !!BMi:T?y1;                           [Creature Type]  
   !!BMi|y1=176/y1=185:U4/17;            [if Temple Guardian Attacker/Defender set to Lightning]


### PR DESCRIPTION
Advanced Classes Mod:

-Fixed a bug: caster spells don't work with amethyst enabled. (https://discord.com/channels/665742159307341827/1288577845219819661)